### PR TITLE
Got an error when hiera file contains an integer

### DIFF
--- a/lib/hiera/backend/yamlgpg_backend.rb
+++ b/lib/hiera/backend/yamlgpg_backend.rb
@@ -90,8 +90,10 @@ class Hiera
                 elsif d.kind_of? Hash
                     d.each_key{|k| d[k] = decrypt_any(d[k])}
                     return d
+                elsif d.kind_of? Fixnum
+                    return d
                 else
-                    raise YamlgpgError, "Expected String, Array, or Hash, got #{d.class}"
+                    raise YamlgpgError, "Expected String, Array, Hash or Fixnum got #{d.class}"
                 end
             end
 


### PR DESCRIPTION
If I put in my hiera
users::base:
  john:
    ensure: present
    uid: 2001

it returns an error because 2001 is not quotted.