### PR TITLE
Update yamlgpg_backend.rb

### DIFF
--- a/lib/hiera/backend/yamlgpg_backend.rb
+++ b/lib/hiera/backend/yamlgpg_backend.rb
@@ -58,7 +58,7 @@ class Hiera
                         when :hash
                             raise Exception, "Hiera type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
                             answer ||= {}
-                            answer = decrypt_any(new_answer).merge answer
+                            answer = Backend.merge_answer(decrypt_any(new_answer), answer)
                         else
                             answer = decrypt_any(new_answer)
                             break


### PR DESCRIPTION
Updated to get yamlgpg to respect merge_behavior configuration; yamlgpg backend currently explicitly does a native merge for hashes. 